### PR TITLE
[Fix] Add sample blog page

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Prismic Blog</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 40px;
+            background-color: #f5f5f5;
+            color: #333;
+        }
+        header {
+            text-align: center;
+            margin-bottom: 40px;
+        }
+        h1 {
+            font-size: 2.5rem;
+            margin: 0;
+        }
+        .tagline {
+            color: #777;
+            margin-top: 10px;
+        }
+        .posts {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 20px;
+        }
+        .post {
+            background-color: #fff;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .post img {
+            width: 100%;
+            height: auto;
+            border-radius: 4px;
+        }
+        .post h2 {
+            font-size: 1.5rem;
+            margin-top: 15px;
+        }
+        .post p {
+            line-height: 1.6;
+            margin-top: 10px;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Prismic Blog</h1>
+        <p class="tagline">Insights and updates from the Prismic team</p>
+    </header>
+    <main>
+        <section class="posts">
+            <article class="post">
+                <img src="https://via.placeholder.com/400x200" alt="Blog Post 1">
+                <h2>Getting Started with Prismic</h2>
+                <p>Learn how to set up your first project and manage content efficiently.</p>
+            </article>
+            <article class="post">
+                <img src="https://via.placeholder.com/400x200" alt="Blog Post 2">
+                <h2>Integrating with Modern Frameworks</h2>
+                <p>Discover how Prismic works seamlessly with popular web frameworks.</p>
+            </article>
+            <article class="post">
+                <img src="https://via.placeholder.com/400x200" alt="Blog Post 3">
+                <h2>Tips for Building a SaaS Landing Page</h2>
+                <p>Best practices and design ideas for a high-converting landing page.</p>
+            </article>
+        </section>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Add a new `blog.html` page providing a basic blog layout with a header and sample posts.

## Testing Done
- `flake8` *(failed: command not found)*
- `pytest tests/` *(no tests found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686e6e930ab883298325d7209c51e255